### PR TITLE
Minor fix

### DIFF
--- a/src/builtins.ml
+++ b/src/builtins.ml
@@ -7,7 +7,7 @@ let num_num_op s op =
   | [] -> failwith @@ Printf.sprintf "Numeric op %s applied to empty list" s
   | y::ys -> Val.Int (List.fold_left op y ys)
   in
-  Val.Op (s, f)
+  Val.Op(s, f)
 
 let num_bool_op s op =
   let g = function
@@ -23,7 +23,7 @@ let num_bool_op s op =
   | [_] -> failwith @@ Printf.sprintf "NumBool op %s applied to one arg" s
   | ys -> h op ys
   in
-  Val.Op (s, f)
+  Val.Op(s, f)
 
 let not_equal_op =
   let g = function
@@ -47,7 +47,7 @@ let bool_bool_op s op =
   | _ -> failwith @@ "Non-boolean value passed to bool op " ^ s
   in
   let f xs = Val.Bool (List.fold_left (fun x y -> op x @@ g y) true xs) in
-  Val.Op (s, f)
+  Val.Op(s, f)
 
 let not_op = function
   | [Val.Bool b] -> Val.Bool (not b)

--- a/src/execute.ml
+++ b/src/execute.ml
@@ -36,12 +36,12 @@ let eval env cont = function
 | Exp.Lets((s, e1)::ves, e2) -> Eval([]::env, Cont.Lets(s, ves, e2)::Cont.Env::cont, e1)
 | Exp.Lets _ -> failwith "Evaluating empty Let"
 | Exp.Fn(params, body) as e ->
-    let free = get_free Env.empty e in
+    let free = Utils.dedupe @@ get_free Env.empty e in
     let fvals = List.map (fun v -> v, Env.find v env) free in
     ApplyCont(env, cont, Val.Fn("anon", params, fvals, body))
 | Exp.LetFn(fns, e) ->
     let f (fname, params, body) =
-      let free = get_free (Env.add_vars Env.empty params) body in
+      let free = Utils.dedupe @@ get_free (Env.add_vars Env.empty params) body in
       let fvals = List.map (fun v -> v, Env.find v env) free in
       (fname, Val.Fn(fname, params, fvals, body))
     in
@@ -49,7 +49,7 @@ let eval env cont = function
 | Exp.LetRec(fns, e) ->
     let fnames, _, _ = Utils.split3 fns in
     let f fnames (fname, params, body) =
-      let free = get_free (Env.add_vars Env.empty (fnames @ params)) body in
+      let free = Utils.dedupe @@ get_free (Env.add_vars Env.empty (fnames @ params)) body in
       let fvals = List.map (fun v -> v, Env.find v env) free in
       let fvalsr = ref fvals in
       let fn = Val.RecFn(fname, params, fvalsr, body) in

--- a/src/execute.ml
+++ b/src/execute.ml
@@ -83,7 +83,7 @@ let apply_cont env cont v = match cont with
   | Val.Bool b -> Eval(env, cont', if b then e2 else e3)
   | _ -> failwith "Non-boolean in condition position of If expression")
 | Cont.Let(s, [], vvs, e2) :: cont' ->
-    let env' = Env.extend_list (List.rev ((s, v)::vvs)) env in
+    let env' = Env.extend_list ((s, v)::vvs) env in
     Eval(env', Cont.Env::cont', e2)
 | Cont.Let(s, (s', e')::ves, vvs, e2) :: cont' ->
     Eval(env, Cont.Let(s', ves, (s, v)::vvs, e2) :: cont', e')

--- a/src/execute.ml
+++ b/src/execute.ml
@@ -33,7 +33,7 @@ let eval env cont = function
 | Exp.If(e1, e2, e3) -> Eval(env, Cont.If(e2, e3) :: cont, e1)
 | Exp.Let((s, e1)::ves, e2) -> Eval(env, Cont.Let(s, ves, [], e2) :: cont, e1)
 | Exp.Let _ -> failwith "Evaluating empty Let"
-| Exp.Lets((s, e1)::ves, e2) -> Eval([]::env, Cont.Lets(s, ves, e2) :: cont, e1)
+| Exp.Lets((s, e1)::ves, e2) -> Eval([]::env, Cont.Lets(s, ves, e2) :: Cont.Env :: cont, e1)
 | Exp.Lets _ -> failwith "Evaluating empty Let"
 | Exp.Fn(params, body) as e ->
     let free = get_free Env.empty e in
@@ -88,7 +88,7 @@ let apply_cont env cont v = match cont with
 | Cont.Let(s, (s', e')::ves, vvs, e2) :: cont' ->
     Eval(env, Cont.Let(s', ves, (s, v)::vvs, e2) :: cont', e')
 | Cont.Lets(s, [], e2) :: cont' ->
-    Eval(Env.extend_current s v env, Cont.Env::cont', e2)
+    Eval(Env.extend_current s v env, cont', e2)
 | Cont.Lets(s, (s', e')::ves, e2) :: cont' ->
     Eval(Env.extend_current s v env, Cont.Lets(s', ves, e2) :: cont', e')
 | Cont.Env :: cont' -> ApplyCont (Env.pop env, cont', v)

--- a/src/execute.ml
+++ b/src/execute.ml
@@ -33,7 +33,7 @@ let eval env cont = function
 | Exp.If(e1, e2, e3) -> Eval(env, Cont.If(e2, e3) :: cont, e1)
 | Exp.Let((s, e1)::ves, e2) -> Eval(env, Cont.Let(s, ves, [], e2) :: cont, e1)
 | Exp.Let _ -> failwith "Evaluating empty Let"
-| Exp.Lets((s, e1)::ves, e2) -> Eval([]::env, Cont.Lets(s, ves, e2) :: Cont.Env :: cont, e1)
+| Exp.Lets((s, e1)::ves, e2) -> Eval([]::env, Cont.Lets(s, ves, e2)::Cont.Env::cont, e1)
 | Exp.Lets _ -> failwith "Evaluating empty Let"
 | Exp.Fn(params, body) as e ->
     let free = get_free Env.empty e in

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -12,31 +12,31 @@ type t =
 let rec to_string = function
 | Int n -> string_of_int n
 | Var s -> s
-| Call (e, []) -> Printf.sprintf "(%s)" @@ to_string e 
-| Call (e, es) ->
+| Call(e, []) -> Printf.sprintf "(%s)" @@ to_string e 
+| Call(e, es) ->
     let fn = to_string e in
     let args = List.map to_string es |> String.concat " " in
     Printf.sprintf "(%s %s)" fn args
-| If (e1, e2, e3) ->
+| If(e1, e2, e3) ->
     let s1 = (to_string e1) in
     let s2 = (to_string e2) in
     let s3 = (to_string e3) in
     Printf.sprintf "(if %s %s %s)" s1 s2 s3
-| Let (ves, e2) ->
+| Let(ves, e2) ->
     let vess = to_string_ves ves in
     let s2 = to_string e2 in
     Printf.sprintf "(let [%s] %s)" vess s2
-| Lets (ves, e2) ->
+| Lets(ves, e2) ->
     let vess = to_string_ves ves in
     let s2 = to_string e2 in
     Printf.sprintf "(let* [%s] %s)" vess s2
-| Fn (params, body) ->
+| Fn(params, body) ->
     Printf.sprintf "(fn [%s] %s)" (String.concat " " params) (to_string body)
-| LetFn (fns, e) ->
+| LetFn(fns, e) ->
     let fns_s = to_string_fns fns in
     let exp_s = to_string e in
     Printf.sprintf "(letfn [%s] %s)" fns_s exp_s
-| LetRec (fns, e) ->
+| LetRec(fns, e) ->
     let fns_s = to_string_fns fns in
     let exp_s = to_string e in
     Printf.sprintf "(letfn [%s] %s)" fns_s exp_s

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -21,20 +21,20 @@ f : e = expr; EOF { e }
 expr :
 | n = INT; { Exp.Int n }
 | s = VAR; { Exp.Var s }
-| LPAREN; e = expr; es = list (expr); RPAREN { Exp.Call (e, es) }
-| LPAREN; IF; e1 = expr; e2 = expr; e3 = expr; RPAREN { Exp.If (e1, e2, e3) }
-| LPAREN; LET; LBRACK; v1 = VAR; e1 = expr; RBRACK; e2 = expr; RPAREN { Exp.Let ([(v1, e1)], e2) }
-| LPAREN; LET; LBRACK; ves = nonempty_list(var_exp); RBRACK; e2 = expr; RPAREN { Exp.Let (ves, e2) }
-| LPAREN; LETS; LBRACK; ves = nonempty_list(var_exp); RBRACK; e2 = expr; RPAREN { Exp.Lets (ves, e2) }
-| LPAREN; FN; LBRACK; ss = list(VAR); RBRACK; e = expr; RPAREN { Exp.Fn (ss, e) }
+| LPAREN; e = expr; es = list (expr); RPAREN { Exp.Call(e, es) }
+| LPAREN; IF; e1 = expr; e2 = expr; e3 = expr; RPAREN { Exp.If(e1, e2, e3) }
+| LPAREN; LET; LBRACK; v1 = VAR; e1 = expr; RBRACK; e2 = expr; RPAREN { Exp.Let([(v1, e1)], e2) }
+| LPAREN; LET; LBRACK; ves = nonempty_list(var_exp); RBRACK; e2 = expr; RPAREN { Exp.Let(ves, e2) }
+| LPAREN; LETS; LBRACK; ves = nonempty_list(var_exp); RBRACK; e2 = expr; RPAREN { Exp.Lets(ves, e2) }
+| LPAREN; FN; LBRACK; ss = list(VAR); RBRACK; e = expr; RPAREN { Exp.Fn(ss, e) }
 | LPAREN; LETFN; LBRACK; fn = func; RBRACK; e = expr; RPAREN
-    { Exp.LetFn ([fn], e) }
+    { Exp.LetFn([fn], e) }
 | LPAREN; LETFN; LBRACK; fns = list(funcp); RBRACK; e = expr; RPAREN
-    { Exp.LetFn (fns, e) }
+    { Exp.LetFn(fns, e) }
 | LPAREN; LETREC; LBRACK; fn = func; RBRACK; e = expr; RPAREN
-    { Exp.LetRec ([fn], e) }
+    { Exp.LetRec([fn], e) }
 | LPAREN; LETREC; LBRACK; fns = list(funcp); RBRACK; e = expr; RPAREN
-    { Exp.LetRec (fns, e) }
+    { Exp.LetRec(fns, e) }
 
 var_exp :
 | LPAREN; v = VAR; e = expr; RPAREN { (v, e) }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -27,8 +27,8 @@ expr :
 | LPAREN; LET; LBRACK; ves = nonempty_list(var_exp); RBRACK; e2 = expr; RPAREN { Exp.Let (ves, e2) }
 | LPAREN; LETS; LBRACK; ves = nonempty_list(var_exp); RBRACK; e2 = expr; RPAREN { Exp.Lets (ves, e2) }
 | LPAREN; FN; LBRACK; ss = list(VAR); RBRACK; e = expr; RPAREN { Exp.Fn (ss, e) }
-| LPAREN; LETFN; LBRACK; fname = VAR; LBRACK; ss = list(VAR); RBRACK; body = expr; RBRACK; e = expr; RPAREN
-    { Exp.LetFn ([(fname, ss, body)], e) }
+| LPAREN; LETFN; LBRACK; fn = func; RBRACK; e = expr; RPAREN
+    { Exp.LetFn ([fn], e) }
 | LPAREN; LETFN; LBRACK; fns = list(funcp); RBRACK; e = expr; RPAREN
     { Exp.LetFn (fns, e) }
 | LPAREN; LETREC; LBRACK; fn = func; RBRACK; e = expr; RPAREN

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -4,3 +4,13 @@ let split3 xyzs =
   | (x,y,z)::xyzs -> f (x::xs) (y::ys) (z::zs) xyzs
   in
   f [] [] [] xyzs
+
+let dedupe xs =
+  let hsh = Hashtbl.create 1024 in
+  let rec f acc = function
+  | [] -> acc
+  | x::xs' ->
+    if Hashtbl.mem hsh x then f acc xs'
+    else (Hashtbl.add hsh x 0; f (x::acc) xs')
+  in
+  f [] xs

--- a/src/val.ml
+++ b/src/val.ml
@@ -8,6 +8,6 @@ type t =
 let to_string = function
 | Int n -> string_of_int n
 | Bool b -> string_of_bool b
-| Op (s, _) -> Printf.sprintf "Op(%s)" s
-| Fn (s, _, _, _) -> Printf.sprintf "Fn(%s)" s
-| RecFn (s, _, _, _) -> Printf.sprintf "FnRec(%s)" s
+| Op(s, _) -> Printf.sprintf "Op(%s)" s
+| Fn(s, _, _, _) -> Printf.sprintf "Fn(%s)" s
+| RecFn(s, _, _, _) -> Printf.sprintf "FnRec(%s)" s


### PR DESCRIPTION
* Modify parser for single letfn
* Add Cont.Env for let* when Exp.Lets is evaluated
* Remove unnecessary reversing for Cont.Let
* Remove spaces in constructors
* Dedupe free variables