### PR TITLE
Implement Modules

### DIFF
--- a/src/exp.ml
+++ b/src/exp.ml
@@ -14,6 +14,7 @@ type t =
 | Do of t list
 | Reset of t
 | Shift of string * t
+| Define of string * t
 
 let rec to_string = function
 | Int n -> string_of_int n
@@ -55,6 +56,7 @@ let rec to_string = function
     Printf.sprintf "(macro [%s] %s)" (String.concat " " params) (to_string body)
 | Reset e -> Printf.sprintf "(reset %s)" @@ to_string e
 | Shift(s, e) -> Printf.sprintf "(shift [%s] %s)" s @@ to_string e
+| Define(s, e) -> Printf.sprintf "(define %s %s)" s @@ to_string e
 and to_string_ves ves =
   let f (s, e) = Printf.sprintf "(%s %s)" s (to_string e) in
   List.map f ves |> String.concat " "
@@ -96,3 +98,4 @@ let rec get_free bound free = function
 | Do es -> List.fold_left (get_free bound) free es
 | Reset e -> get_free bound free e
 | Shift(s, e) -> get_free (s::bound) free e
+| Define(_, e) -> get_free bound free e

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -15,6 +15,7 @@ type t =
 | Reset of t
 | Shift of string * t
 | Define of string * t
+| Module of t list
 
 let rec to_string = function
 | Int n -> string_of_int n
@@ -57,6 +58,7 @@ let rec to_string = function
 | Reset e -> Printf.sprintf "(reset %s)" @@ to_string e
 | Shift(s, e) -> Printf.sprintf "(shift [%s] %s)" s @@ to_string e
 | Define(s, e) -> Printf.sprintf "(define %s %s)" s @@ to_string e
+| Module es -> Printf.sprintf "(module [%s])" @@ String.concat " " @@ List.map to_string es
 and to_string_ves ves =
   let f (s, e) = Printf.sprintf "(%s %s)" s (to_string e) in
   List.map f ves |> String.concat " "
@@ -99,3 +101,6 @@ let rec get_free bound free = function
 | Reset e -> get_free bound free e
 | Shift(s, e) -> get_free (s::bound) free e
 | Define(_, e) -> get_free bound free e
+| Module [] -> free
+| Module((Define(s,e))::es) -> get_free (s::bound) (get_free bound free e) (Module es)
+| Module(e::es) -> get_free bound (get_free bound free e) (Module es)

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -2,6 +2,7 @@ type t =
 | Int of int
 | Str of string
 | Var of string
+| MVar of string list
 | Call of t * t list
 | If of t * t * t
 | Cond of (t * t) list
@@ -21,6 +22,7 @@ let rec to_string = function
 | Int n -> string_of_int n
 | Str s -> Printf.sprintf "\"%s\"" s
 | Var s -> s
+| MVar ss -> String.concat "." ss
 | Call(e, []) -> Printf.sprintf "(%s)" @@ to_string e 
 | Call(e, es) ->
     let fn = to_string e in
@@ -73,6 +75,8 @@ and to_string_fns fns =
 let rec get_free bound free = function
 | Int _ | Str _ | Macro _ -> free
 | Var s -> if (List.mem s bound) then free else s::free
+| MVar [] -> free
+| MVar(s::_) -> if (List.mem s bound) then free else s::free
 | Call(e, es) -> List.fold_left (get_free bound) free @@ e::es
 | If(e1, e2, e3) -> List.fold_left (get_free bound) free [e1; e2; e3]
 | Cond(ees) ->

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -24,5 +24,7 @@ rule f = parse
   | "do" { Parser.DO }
   | "reset" { Parser.RESET }
   | "shift" { Parser.SHIFT }
+  | "define" { Parser.DEFINE }
+  | "module" { Parser.MODULE }
   | variable as s { Parser.VAR s }
   | eof { EOF }

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -3,6 +3,7 @@ let digit = ['0'-'9']
 let char = ['a'-'z' 'A'-'Z' '+' '-' '*' '/' '<' '>' '=' '!' '?' '_']
 let number = ('0'|['1'-'9'] digit*)
 let variable = char (char|digit)*
+let mvariable = variable '.' variable ('.' variable)*
 let string = '"' + (' '|char|number)* '"'
 
 rule f = parse
@@ -26,5 +27,6 @@ rule f = parse
   | "shift" { Parser.SHIFT }
   | "define" { Parser.DEFINE }
   | "module" { Parser.MODULE }
+  | mvariable as s { Parser.MVAR (String.split_on_char '.' s) }
   | variable as s { Parser.VAR s }
   | eof { EOF }

--- a/src/macro.ml
+++ b/src/macro.ml
@@ -7,6 +7,7 @@ let substitute e ss es =
   | Exp.Var s as e -> (match List.assoc_opt s env with
     | Some e' -> e'
     | None -> e)
+  | Exp.MVar _ as x -> x
   | Exp.Call(e, es) -> Exp.Call(f e, List.map f es)
   | Exp.If(e1, e2, e3) -> Exp.If(f e1, f e2, f e3)
   | Exp.Cond(ees) ->

--- a/src/macro.ml
+++ b/src/macro.ml
@@ -23,5 +23,7 @@ let substitute e ss es =
   | Exp.Do es -> Exp.Do (List.map f es)
   | Exp.Reset e -> Exp.Reset (f e)
   | Exp.Shift(s, e) -> Exp.Shift(s, f e)
+  | Exp.Define(s, e) -> Exp.Define(s, f e)
+  | Exp.Module es -> Exp.Module (List.map f es)
 in
 f e

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -1,5 +1,6 @@
 %token <int> INT
 %token <string> VAR
+%token <string list> MVAR
 %token <string> STR
 %token LPAREN
 %token RPAREN
@@ -29,6 +30,7 @@ f : e = expr; EOF { e }
 expr :
 | n = INT; { Exp.Int n }
 | s = VAR; { Exp.Var s }
+| ss = MVAR; { Exp.MVar ss }
 | s = STR; { Exp.Str s }
 | LPAREN; e = expr; es = list (expr); RPAREN { Exp.Call(e, es) }
 | LPAREN; IF; e1 = expr; e2 = expr; e3 = expr; RPAREN { Exp.If(e1, e2, e3) }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -52,7 +52,7 @@ expr :
 | LPAREN; MODULE; LBRACK; es = nonempty_list(module_expr); RBRACK; RPAREN { Exp.Module es }
 
 module_expr :
-| expr
+| e = expr { e }
 | LPAREN; DEFINE; s = VAR; e = expr; RPAREN { Exp.Define(s, e) }
 
 var_exp :

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -16,6 +16,8 @@
 %token DO
 %token RESET
 %token SHIFT
+%token DEFINE
+%token MODULE
 %token EOF
 
 %start <Exp.t> f
@@ -47,6 +49,11 @@ expr :
 | LPAREN; DO; LBRACK; es = nonempty_list(expr); RBRACK; RPAREN; { Exp.Do es }
 | LPAREN; RESET; e = expr; RPAREN { Exp.Reset e }
 | LPAREN; SHIFT; LBRACK; s = VAR; RBRACK; e = expr; RPAREN { Exp.Shift(s, e) }
+| LPAREN; MODULE; LBRACK; es = nonempty_list(module_expr); RBRACK; RPAREN { Exp.Module es }
+
+module_expr :
+| expr
+| LPAREN; DEFINE; s = VAR; e = expr; RPAREN { Exp.Define(s, e) }
 
 var_exp :
 | LPAREN; v = VAR; e = expr; RPAREN { (v, e) }

--- a/test/dune
+++ b/test/dune
@@ -8,5 +8,6 @@
     test_cons
     test_cond
     test_side_effect
-    test_macro)
+    test_macro
+    test_module)
   (libraries ounit2 kontlang))

--- a/test/test_module.ml
+++ b/test/test_module.ml
@@ -1,0 +1,29 @@
+open OUnit2
+open Kontlang
+
+let test_module1 _ =
+  let s = "(let [M (module [(define x 10)])] M.x)" in
+  assert_equal (Execute.eval_string s) "10"
+
+let test_module2 _ =
+  let s = "(let [M (module [(+ 1 2) (define x 10)])] M.x)" in
+  assert_equal (Execute.eval_string s) "10"
+
+let test_nested_module1 _ =
+  let s =
+  "(let [M (module
+             [(define x 10)
+              (define Y (module [(define z 5)]))])]
+     (+ M.x M.Y.z))"
+  in
+  assert_equal (Execute.eval_string s) "15"
+
+let suite =
+  "MacroTestList" >::: [
+    "test_module1" >:: test_module1
+  ; "test_module2" >:: test_module2
+  ; "test_nested_module1" >:: test_nested_module1
+  ]
+
+let () =
+  run_test_tt_main suite


### PR DESCRIPTION
Implement first-class modules
* `module` keyword to create an anonymous module object
* `define` keyword to create variables within modules
* dotted notation `M.x` to access variables in a module