### PR TITLE
Open/Include/Using

### DIFF
--- a/src/env.ml
+++ b/src/env.ml
@@ -7,6 +7,9 @@ let extend_current var val_ = function
 | [] -> [[(var, val_)]]
 | env::env' -> ((var, val_)::env)::env'
 let extend_list vvs env = vvs :: env
+let extend_list_current vvs = function
+| [] -> [vvs]
+|env::env' -> (vvs @ env)::env'
 
 let rec find var = function
 | [] -> failwith @@ Printf.sprintf "Variable %s not found" var

--- a/src/env.ml
+++ b/src/env.ml
@@ -15,6 +15,13 @@ let rec find var = function
     if var = var' then val'
     else find var @@ env'::env''
 
+let rec find_opt var = function
+| [] -> None
+| []::env' -> find_opt var env'
+| ((var', val')::env')::env'' ->
+    if var = var' then Some val'
+    else find_opt var @@ env'::env''
+
 let pop = function
 | [] -> failwith "Popping empty environment"
 | svs::env -> svs, env

--- a/src/execute.ml
+++ b/src/execute.ml
@@ -51,12 +51,12 @@ let eval env cont = function
 | Exp.Lets _ -> failwith "Evaluating empty Let"
 | Exp.Fn(params, body) as e ->
   let free = Utils.dedupe @@ Exp.get_free [] [] e in
-  let fvalsr = ref @@ List.map (fun v -> v, Env.find v env) free in
+  let fvalsr = ref @@ make_closure env free in
   ApplyCont(env, cont, Val.Fn("anon", params, fvalsr, body))
 | Exp.LetFn(fns, e) ->
   let f (fname, params, body) =
     let free = Utils.dedupe @@ Exp.get_free params [] body in
-    let fvalsr = ref @@ List.map (fun v -> v, Env.find v env) free in
+    let fvalsr = ref @@ make_closure env free in
     (fname, Val.Fn(fname, params, fvalsr, body))
   in
   Eval(Env.extend_list (List.map f fns) env, Cont.add Cont.Env cont, e)
@@ -64,8 +64,7 @@ let eval env cont = function
   let fnames, _, _ = Utils.split3 fns in
   let f (fname, params, body) =
     let free = Utils.dedupe @@ Exp.get_free (fnames @ params) [] body in
-    let fvals = List.map (fun v -> v, Env.find v env) free in
-    let fvalsr = ref fvals in
+    let fvalsr = ref @@ make_closure env free in
     let fn = Val.Fn(fname, params, fvalsr, body) in
     ((fname, fn), fvalsr)
   in
@@ -79,11 +78,11 @@ let eval env cont = function
 | Exp.Do([]) -> failwith "Evaluating empty do"
 | Exp.Reset e ->
   let free = Utils.dedupe @@ Exp.get_free [] [] e in
-  let fvals = List.map (fun v -> v, Env.find v env) free in
+  let fvals = make_closure env free in
   Eval(Env.extend_list fvals env, []::cont, e)
 | Exp.Shift(s, e) ->
   let free = Utils.dedupe @@ Exp.get_free [s] [] e in
-  let fvals = List.map (fun v -> v, Env.find v env) free in
+  let fvals = make_closure env free in
   let cont', cont'' = Cont.pop cont in
   let n = 1 + Utils.count Cont.Env cont' in
   let env', env'' = Utils.break_off n env in

--- a/src/execute.ml
+++ b/src/execute.ml
@@ -3,6 +3,15 @@ type t =
 | Eval of Env.t * Cont.t * Exp.t
 | ApplyCont of Env.t * Cont.t * Val.t
 
+let make_closure env free =
+  let rec f acc = function
+  | [] -> List.rev acc
+  | s::ss -> (match Env.find_opt s env with
+    | None -> f acc ss
+    | Some v -> f ((s, v)::acc) ss)
+  in
+  f [] free
+
 let rec tco env = function
 | (Cont.Env::cont)::cont' -> tco (Env.rest env) @@ cont::cont'
 | cont -> env, cont

--- a/src/execute.ml
+++ b/src/execute.ml
@@ -101,6 +101,7 @@ let eval env cont = function
 | Exp.Module [] -> ApplyCont(env, cont, Val.Module [])
 | Exp.Import e -> Eval(env, Cont.add Cont.Import cont, e)
 | Exp.Open(m, e) -> Eval(env, Cont.add (Cont.Open e) cont, m)
+| Exp.Include _ -> failwith "Include used outside of Module definition"
 
 
 let apply_cont env cont v = match cont with
@@ -165,6 +166,10 @@ let apply_cont env cont v = match cont with
     let env' = Env.extend_current s v env in
     let cont''' = Cont.add (Cont.ModuleDefine(s', es, (s,v)::svs)) (cont'::cont'')in
     Eval(env', cont''', e')
+| (Cont.ModuleDefine(s, Exp.Include(m)::es, svs)::cont')::cont'' ->
+    let env' = Env.extend_current s v env in
+    let cont''' = Cont.add (Cont.ModuleInclude(es, (s,v)::svs)) (cont'::cont'')in
+    Eval(env', cont''', m)
 | (Cont.ModuleDefine(s, e::es, svs)::cont')::cont'' ->
     let env' = Env.extend_current s v env in
     let cont''' = Cont.add (Cont.ModuleExp(es, (s,v)::svs)) (cont'::cont'')in
@@ -174,9 +179,39 @@ let apply_cont env cont v = match cont with
 | (Cont.ModuleExp(Exp.Define(s', e')::es, svs)::cont')::cont'' ->
     let cont''' = Cont.add (Cont.ModuleDefine(s', es, svs)) (cont'::cont'')in
     Eval(env, cont''', e')
+| (Cont.ModuleExp(Exp.Include(m)::es, svs)::cont')::cont'' ->
+    let cont''' = Cont.add (Cont.ModuleInclude(es, svs)) (cont'::cont'')in
+    Eval(env, cont''', m)
 | (Cont.ModuleExp(e::es, svs)::cont')::cont'' ->
     let cont''' = Cont.add (Cont.ModuleExp(es, svs)) (cont'::cont'')in
     Eval(env, cont''', e)
+| (Cont.ModuleInclude([], svs)::cont')::cont'' -> (match v with
+  | Val.Module _ -> ApplyCont(env, cont'::cont'', Val.Module svs)
+  | _ -> failwith "Non-module passed to Include")
+| (Cont.ModuleInclude(Exp.Define(s', e')::es, svs)::cont')::cont'' -> (match v with
+  | Val.Module svs' ->
+    let env' = Env.extend_list svs' env in
+    let cont1 = cont'::cont'' in
+    let cont2 = Cont.add Cont.Env cont1 in
+    let cont3 = Cont.add (Cont.ModuleDefine(s', es, svs)) cont2 in
+    Eval(env', cont3, e')
+  | _ -> failwith "Non-module passed to Include")
+| (Cont.ModuleInclude(Exp.Include(m)::es, svs)::cont')::cont'' -> (match v with
+  | Val.Module svs' ->
+    let env' = Env.extend_list svs' env in
+    let cont1 = cont'::cont'' in
+    let cont2 = Cont.add Cont.Env cont1 in
+    let cont3 = Cont.add (Cont.ModuleInclude(es, svs)) cont2 in
+    Eval(env', cont3, m)
+  | _ -> failwith "Non-module passed to Include")
+| (Cont.ModuleInclude(e::es, svs)::cont')::cont'' -> (match v with
+  | Val.Module svs' ->
+    let env' = Env.extend_list svs' env in
+    let cont1 = cont'::cont'' in
+    let cont2 = Cont.add Cont.Env cont1 in
+    let cont3 = Cont.add (Cont.ModuleExp(es, svs)) cont2 in
+    Eval(env', cont3, e)
+  | _ -> failwith "Non-module passed to Include")
 | (Cont.Import :: cont')::cont'' -> (match v with
   | Val.Str s ->
     let s' = Std.input_all (open_in s) in

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -20,6 +20,7 @@ type t =
 | Import of t
 | Open of t * t
 | Include of t
+| Using of t
 
 let rec to_string = function
 | Int n -> string_of_int n
@@ -67,6 +68,7 @@ let rec to_string = function
 | Import e -> Printf.sprintf "(import \"%s\")" @@ to_string e
 | Open(m, e) -> Printf.sprintf "(open %s %s)" (to_string m) (to_string e)
 | Include m -> Printf.sprintf "(include %s)" (to_string m)
+| Using m -> Printf.sprintf "(using %s)" (to_string m)
 and to_string_ves ves =
   let f (s, e) = Printf.sprintf "(%s %s)" s (to_string e) in
   List.map f ves |> String.concat " "
@@ -119,3 +121,4 @@ let rec get_free bound free = function
     fst @@ List.fold_left f (free, bound) es
 | Open(m, e) -> get_free bound (get_free bound free m) e
 | Include m -> get_free bound free m
+| Using m -> get_free bound free m

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -18,6 +18,7 @@ type t =
 | Define of string * t
 | Module of t list
 | Import of t
+| Open of t * t
 
 let rec to_string = function
 | Int n -> string_of_int n
@@ -63,6 +64,7 @@ let rec to_string = function
 | Define(s, e) -> Printf.sprintf "(define %s %s)" s @@ to_string e
 | Module es -> Printf.sprintf "(module [%s])" @@ String.concat " " @@ List.map to_string es
 | Import e -> Printf.sprintf "(import \"%s\")" @@ to_string e
+| Open(m, e) -> Printf.sprintf "(open %s %s)" (to_string m) (to_string e)
 and to_string_ves ves =
   let f (s, e) = Printf.sprintf "(%s %s)" s (to_string e) in
   List.map f ves |> String.concat " "
@@ -113,3 +115,4 @@ let rec get_free bound free = function
     | e -> (get_free bound free e, bound)
     in
     fst @@ List.fold_left f (free, bound) es
+| Open(m, e) -> get_free bound (get_free bound free m) e

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -107,6 +107,9 @@ let rec get_free bound free = function
 | Reset e -> get_free bound free e
 | Shift(s, e) -> get_free (s::bound) free e
 | Define(_, e) -> get_free bound free e
-| Module [] -> free
-| Module((Define(s,e))::es) -> get_free (s::bound) (get_free bound free e) (Module es)
-| Module(e::es) -> get_free bound (get_free bound free e) (Module es)
+| Module es ->
+    let f (free, bound) = function
+    | Define(s,e) -> (get_free bound free e, s::bound)
+    | e -> (get_free bound free e, bound)
+    in
+    fst @@ List.fold_left f (free, bound) es

--- a/src/exp.ml
+++ b/src/exp.ml
@@ -19,6 +19,7 @@ type t =
 | Module of t list
 | Import of t
 | Open of t * t
+| Include of t
 
 let rec to_string = function
 | Int n -> string_of_int n
@@ -65,6 +66,7 @@ let rec to_string = function
 | Module es -> Printf.sprintf "(module [%s])" @@ String.concat " " @@ List.map to_string es
 | Import e -> Printf.sprintf "(import \"%s\")" @@ to_string e
 | Open(m, e) -> Printf.sprintf "(open %s %s)" (to_string m) (to_string e)
+| Include m -> Printf.sprintf "(include %s)" (to_string m)
 and to_string_ves ves =
   let f (s, e) = Printf.sprintf "(%s %s)" s (to_string e) in
   List.map f ves |> String.concat " "
@@ -116,3 +118,4 @@ let rec get_free bound free = function
     in
     fst @@ List.fold_left f (free, bound) es
 | Open(m, e) -> get_free bound (get_free bound free m) e
+| Include m -> get_free bound free m

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -28,6 +28,7 @@ rule f = parse
   | "define" { Parser.DEFINE }
   | "module" { Parser.MODULE }
   | "import" { Parser.IMPORT }
+  | "open" { Parser.OPEN }
   | mvariable as s { Parser.MVAR (String.split_on_char '.' s) }
   | variable as s { Parser.VAR s }
   | eof { EOF }

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -29,6 +29,7 @@ rule f = parse
   | "module" { Parser.MODULE }
   | "import" { Parser.IMPORT }
   | "open" { Parser.OPEN }
+  | "include" { Parser.INCLUDE }
   | mvariable as s { Parser.MVAR (String.split_on_char '.' s) }
   | variable as s { Parser.VAR s }
   | eof { EOF }

--- a/src/lexer.mll
+++ b/src/lexer.mll
@@ -30,6 +30,7 @@ rule f = parse
   | "import" { Parser.IMPORT }
   | "open" { Parser.OPEN }
   | "include" { Parser.INCLUDE }
+  | "using" { Parser.USING }
   | mvariable as s { Parser.MVAR (String.split_on_char '.' s) }
   | variable as s { Parser.VAR s }
   | eof { EOF }

--- a/src/macro.ml
+++ b/src/macro.ml
@@ -28,5 +28,6 @@ let substitute e ss es =
   | Exp.Module es -> Exp.Module (List.map f es)
   | Exp.Import e -> Exp.Import (f e)
   | Exp.Open(m, e) -> Exp.Open(f m, f e)
+  | Exp.Include m -> Exp.Include (f m)
 in
 f e

--- a/src/macro.ml
+++ b/src/macro.ml
@@ -29,5 +29,6 @@ let substitute e ss es =
   | Exp.Import e -> Exp.Import (f e)
   | Exp.Open(m, e) -> Exp.Open(f m, f e)
   | Exp.Include m -> Exp.Include (f m)
+  | Exp.Using m -> Exp.Using (f m)
 in
 f e

--- a/src/macro.ml
+++ b/src/macro.ml
@@ -27,5 +27,6 @@ let substitute e ss es =
   | Exp.Define(s, e) -> Exp.Define(s, f e)
   | Exp.Module es -> Exp.Module (List.map f es)
   | Exp.Import e -> Exp.Import (f e)
+  | Exp.Open(m, e) -> Exp.Open(f m, f e)
 in
 f e

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -57,11 +57,11 @@ expr :
 | LPAREN; MODULE; LBRACK; es = nonempty_list(module_expr); RBRACK; RPAREN { Exp.Module es }
 | LPAREN; IMPORT; e = expr; RPAREN { Exp.Import e }
 | LPAREN; OPEN; m = expr; e = expr; RPAREN { Exp.Open(m, e) }
-| LPAREN; INCLUDE; m = expr; RPAREN { Exp.Include m }
 
 module_expr :
 | e = expr { e }
 | LPAREN; DEFINE; s = VAR; e = expr; RPAREN { Exp.Define(s, e) }
+| LPAREN; INCLUDE; m = expr; RPAREN { Exp.Include m }
 
 var_exp :
 | LPAREN; v = VAR; e = expr; RPAREN { (v, e) }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -21,6 +21,7 @@
 %token MODULE
 %token IMPORT
 %token OPEN
+%token INCLUDE
 %token EOF
 
 %start <Exp.t> f
@@ -55,7 +56,8 @@ expr :
 | LPAREN; SHIFT; LBRACK; s = VAR; RBRACK; e = expr; RPAREN { Exp.Shift(s, e) }
 | LPAREN; MODULE; LBRACK; es = nonempty_list(module_expr); RBRACK; RPAREN { Exp.Module es }
 | LPAREN; IMPORT; e = expr; RPAREN { Exp.Import e }
-| LPAREN; IMPORT; m = expr; e = expr; RPAREN { Exp.Open(m, e) }
+| LPAREN; OPEN; m = expr; e = expr; RPAREN { Exp.Open(m, e) }
+| LPAREN; INCLUDE; m = expr; RPAREN { Exp.Include m }
 
 module_expr :
 | e = expr { e }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -20,6 +20,7 @@
 %token DEFINE
 %token MODULE
 %token IMPORT
+%token OPEN
 %token EOF
 
 %start <Exp.t> f
@@ -54,6 +55,7 @@ expr :
 | LPAREN; SHIFT; LBRACK; s = VAR; RBRACK; e = expr; RPAREN { Exp.Shift(s, e) }
 | LPAREN; MODULE; LBRACK; es = nonempty_list(module_expr); RBRACK; RPAREN { Exp.Module es }
 | LPAREN; IMPORT; e = expr; RPAREN { Exp.Import e }
+| LPAREN; IMPORT; m = expr; e = expr; RPAREN { Exp.Open(m, e) }
 
 module_expr :
 | e = expr { e }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -22,6 +22,7 @@
 %token IMPORT
 %token OPEN
 %token INCLUDE
+%token USING
 %token EOF
 
 %start <Exp.t> f
@@ -62,6 +63,7 @@ module_expr :
 | e = expr { e }
 | LPAREN; DEFINE; s = VAR; e = expr; RPAREN { Exp.Define(s, e) }
 | LPAREN; INCLUDE; m = expr; RPAREN { Exp.Include m }
+| LPAREN; USING; m = expr; RPAREN { Exp.Using m }
 
 var_exp :
 | LPAREN; v = VAR; e = expr; RPAREN { (v, e) }

--- a/src/valcont.ml
+++ b/src/valcont.ml
@@ -18,6 +18,7 @@ and contt =
 | Do of Exp.t list
 | ModuleExp of Exp.t list * (string * valt) list
 | ModuleInclude of Exp.t list * (string * valt) list
+| ModuleUsing of Exp.t list * (string * valt) list
 | ModuleDefine of string * Exp.t list * (string * valt) list
 | Import
 | Open of Exp.t
@@ -81,6 +82,7 @@ module Cont = struct
   | Do of Exp.t list
   | ModuleExp of Exp.t list * (string * valt) list
   | ModuleInclude of Exp.t list * (string * valt) list
+  | ModuleUsing of Exp.t list * (string * valt) list
   | ModuleDefine of string * Exp.t list * (string * valt) list
   | Import
   | Open of Exp.t
@@ -131,6 +133,10 @@ module Cont = struct
       let es_str = to_string_es es in
       let svs_str = to_string_svs svs in
       Printf.sprintf "MODULE_INCLUDE [%s] [%s]" es_str svs_str
+  | ModuleUsing(es, svs) ->
+      let es_str = to_string_es es in
+      let svs_str = to_string_svs svs in
+      Printf.sprintf "MODULE_USING [%s] [%s]" es_str svs_str
   | ModuleDefine(s, es, svs) ->
       let es_str = to_string_es es in
       let svs_str = to_string_svs svs in
@@ -148,6 +154,7 @@ module Cont = struct
   | Do _ -> "DO"
   | ModuleExp _ -> "MODULE_EXP"
   | ModuleInclude _ -> "MODULE_INCLUDE"
+  | ModuleUsing _ -> "MODULE_USING"
   | ModuleDefine _ -> "MODULE_DEFINE"
   | Import -> "IMPORT"
   | Open _ -> "OPEN"

--- a/src/valcont.ml
+++ b/src/valcont.ml
@@ -19,6 +19,7 @@ and contt =
 | ModuleExp of Exp.t list * (string * valt) list
 | ModuleDefine of string * Exp.t list * (string * valt) list
 | Import
+| Open of Exp.t
 | Env
 
 module Val = struct
@@ -80,6 +81,7 @@ module Cont = struct
   | ModuleExp of Exp.t list * (string * valt) list
   | ModuleDefine of string * Exp.t list * (string * valt) list
   | Import
+  | Open of Exp.t
   | Env
   
   type t = cont list list
@@ -128,6 +130,7 @@ module Cont = struct
       let svs_str = to_string_svs svs in
       Printf.sprintf "MODULE_DEFINE %s [%s] [%s]" s es_str svs_str
   | Import -> "IMPORT"
+  | Open(e) -> Printf.sprintf "OPEN %s" (Exp.to_string e)
   | Env -> "ENV"
 
   let to_string_cont_short = function
@@ -140,6 +143,7 @@ module Cont = struct
   | ModuleExp _ -> "MODULE_EXP"
   | ModuleDefine _ -> "MODULE_DEFINE"
   | Import -> "IMPORT"
+  | Open _ -> "OPEN"
   | Env -> "ENV"
 
   let to_string cont =

--- a/src/valcont.ml
+++ b/src/valcont.ml
@@ -17,6 +17,7 @@ and contt =
 | Lets of string * (string * Exp.t) list * Exp.t
 | Do of Exp.t list
 | ModuleExp of Exp.t list * (string * valt) list
+| ModuleInclude of Exp.t list * (string * valt) list
 | ModuleDefine of string * Exp.t list * (string * valt) list
 | Import
 | Open of Exp.t
@@ -79,6 +80,7 @@ module Cont = struct
   | Lets of string * (string * Exp.t) list * Exp.t
   | Do of Exp.t list
   | ModuleExp of Exp.t list * (string * valt) list
+  | ModuleInclude of Exp.t list * (string * valt) list
   | ModuleDefine of string * Exp.t list * (string * valt) list
   | Import
   | Open of Exp.t
@@ -125,6 +127,10 @@ module Cont = struct
       let es_str = to_string_es es in
       let svs_str = to_string_svs svs in
       Printf.sprintf "MODULE_EXP [%s] [%s]" es_str svs_str
+  | ModuleInclude(es, svs) ->
+      let es_str = to_string_es es in
+      let svs_str = to_string_svs svs in
+      Printf.sprintf "MODULE_INCLUDE [%s] [%s]" es_str svs_str
   | ModuleDefine(s, es, svs) ->
       let es_str = to_string_es es in
       let svs_str = to_string_svs svs in
@@ -141,6 +147,7 @@ module Cont = struct
   | Lets _ -> "LETS"
   | Do _ -> "DO"
   | ModuleExp _ -> "MODULE_EXP"
+  | ModuleInclude _ -> "MODULE_INCLUDE"
   | ModuleDefine _ -> "MODULE_DEFINE"
   | Import -> "IMPORT"
   | Open _ -> "OPEN"


### PR DESCRIPTION
Add functionality to merge the namespace of a module into the current variable environment

* `(open m e)` makes all variables defined in module `m` available when evaluating expression `e`
* `(include m)` inside a module definition makes all variables defined in module `m` available for subsequent expression evaluation inside the module, and also as part of the module's externally-available namespace
* `(using m)` inside a module definition makes all variables defined in module `m` available for subsequent expression evaluation inside the module, without exposing them in the module's externally-available namespace